### PR TITLE
fix: dbpal.tables.tbls now uses schema in the table name

### DIFF
--- a/dbpal/tables.py
+++ b/dbpal/tables.py
@@ -1,6 +1,6 @@
 import os
 
-from dbcooper import DbCooper, AccessorBuilder
+from dbcooper import DbCooper, AccessorHierarchyBuilder
 from functools import partial
 from dbpal.config import get_sql_engine, get_fs
 from pathlib import Path
@@ -12,7 +12,7 @@ def get_dbc(read_only=True):
     engine = get_sql_engine(read_only)
     dbc = DbCooper(
         engine,
-        accessor_builder = AccessorBuilder(format_from_part="schema")
+        accessor_builder = AccessorHierarchyBuilder()
     )
 
     # if we're using duckdb, then the warehouse is a bunch of parquet files,

--- a/dbpal/tables.py
+++ b/dbpal/tables.py
@@ -12,7 +12,7 @@ def get_dbc(read_only=True):
     engine = get_sql_engine(read_only)
     dbc = DbCooper(
         engine,
-        accessor_builder = AccessorBuilder(format_from_part="table")
+        accessor_builder = AccessorBuilder(format_from_part="schema")
     )
 
     # if we're using duckdb, then the warehouse is a bunch of parquet files,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 keywords = ["data"]
 dependencies = [
-  "plum-dispatch",
+  "plum-dispatch<2.0.0",
   "fsspec",
   "gcsfs",
   "importlib_resources",


### PR DESCRIPTION
dbpal now uses dbcooper's AccessorHierarchyBuilder, to split up database table name parts into their own attribute dictionaries. It also includes the schema in the name.

```
from dbal.tables import tbls

# old
tbls.dim_issues()

# new
tbls.github_extract.dim_issues()